### PR TITLE
Open source link changes: open in new tab and add space after colon

### DIFF
--- a/messages/ru/project.php
+++ b/messages/ru/project.php
@@ -48,7 +48,7 @@ return [
     'Published' => 'Опубликован',
     'Save' => 'Сохранить',
     'Slug' => 'Slug',
-    'Source Code: ' => 'Исходный код:',
+    'Source Code' => 'Исходный код',
     'Source URL' => 'Исходный код',
     'Status' => 'Статус',
     'Tag ID' => 'ID тега',

--- a/views/project/view.php
+++ b/views/project/view.php
@@ -57,7 +57,7 @@ $canManageProject = UserPermissions::canManageProject($model);
             <?php endif ?>
 
             <?php if ($model->is_opensource): ?>
-                <p><?= Yii::t('project', 'Source Code: ') . Html::a(Html::encode($model->source_url), $model->source_url) ?></p>
+                <p><?= Yii::t('project', 'Source Code') ?>: <?= Html::a(Html::encode($model->source_url), $model->source_url, ['target' => '_blank']) ?></p>
             <?php endif ?>
 
             <p><?= Yii::t('project', 'Yii Version') ?>: <?= Html::encode($model->yii_version) ?></p>


### PR DESCRIPTION
I add a space in the view, rather than in the language file, similar to how it is done with the output Yii version below. I think it is better: in language files should be no punctuation, is not it?