### PR TITLE
Fixes #60: UX: upload screen issues

### DIFF
--- a/assets/app/js/main.js
+++ b/assets/app/js/main.js
@@ -56,8 +56,9 @@ jQuery(function ($) {
  * 
  * @param {int} widthMin
  * @param {int} heightMin
+ * @param {string} controlLockMessage
  */
-function initProjectImageUpload(widthMin, heightMin) {
+function initProjectImageUpload(widthMin, heightMin, controlLockMessage) {
     var uploadForm = $('#project-image-upload');
     var imageCropperBlock = uploadForm.find('.cropper-block');
     var imageBlock = imageCropperBlock.find('.image-block');
@@ -66,6 +67,8 @@ function initProjectImageUpload(widthMin, heightMin) {
     var inputFile = uploadForm.find('[name="ImageUploadForm[file]"]');
     var inputImageId = uploadForm.find('[name="ImageUploadForm[imageId]"]');
 
+    var processIsRunning = false;
+    
     imageBlock.cropper({
         viewMode: 1,
         minCropBoxWidth: widthMin,
@@ -95,6 +98,7 @@ function initProjectImageUpload(widthMin, heightMin) {
     });
 
     function clear() {
+        processIsRunning = false;
         imageCropperBlock.hide(0);
         uploadForm.removeClass('opened');
 
@@ -120,6 +124,7 @@ function initProjectImageUpload(widthMin, heightMin) {
                 imageBlock.one('built.cropper', function () {
                     URL.revokeObjectURL(blobURL);
                 }).cropper('reset').cropper('replace', blobURL);
+                processIsRunning = true;
                 imageCropperBlock.show(0);
                 uploadForm.addClass('opened');
             }
@@ -141,6 +146,7 @@ function initProjectImageUpload(widthMin, heightMin) {
         inputImageId.val(imageId);
         imageBlock.cropper('reset').cropper('replace', imageUrl);
 
+        processIsRunning = true;
         imageCropperBlock.show(0);
         uploadForm.addClass('opened');
     });
@@ -153,5 +159,11 @@ function initProjectImageUpload(widthMin, heightMin) {
         }
 
         imageCropperBlock.cropper('reset')
+    });
+
+    $('.control-buttons a').on('click.controlLockMessage', function (e) {
+        if (processIsRunning && !confirm(controlLockMessage)) {
+            e.preventDefault();
+        }
     });
 }

--- a/assets/app/styles/main.less
+++ b/assets/app/styles/main.less
@@ -649,7 +649,7 @@ a {
           padding: 1em 0;
 
           &:first-child {
-            min-width: 50em;
+            min-width: 100%;
             min-height: 30em;
 
             @media (max-width: @screen-sm-max) {

--- a/messages/ru/project.php
+++ b/messages/ru/project.php
@@ -98,4 +98,5 @@ return [
     'You can upload up to 5 images. The first image will be used as a main preview of your project, while others will be displayed on the project details page' => 'Можно загрузить до пяти изображений. Первое изображение используется в карточке проекта, остальные можно посмотреть на странице проекта.',
     'You have no bookmarked projects yet.' => 'В ваших закладках пока нет проектов.',
     '{n, plural, one{# project} other{# projects}} made with {link}' => '{n,plural,one{# проект сделан} few{# проекта сделано} many{# проектов сделано} other{# проектов сделано}} на {link}',
+    'You did not save the image. Are you sure you want to continue?' => 'Вы не сохранили изображение. Уверяны, что хотите продолжить?',
 ];

--- a/messages/ru/project.php
+++ b/messages/ru/project.php
@@ -98,5 +98,5 @@ return [
     'You can upload up to 5 images. The first image will be used as a main preview of your project, while others will be displayed on the project details page' => 'Можно загрузить до пяти изображений. Первое изображение используется в карточке проекта, остальные можно посмотреть на странице проекта.',
     'You have no bookmarked projects yet.' => 'В ваших закладках пока нет проектов.',
     '{n, plural, one{# project} other{# projects}} made with {link}' => '{n,plural,one{# проект сделан} few{# проекта сделано} many{# проектов сделано} other{# проектов сделано}} на {link}',
-    'You did not save the image. Are you sure you want to continue?' => 'Вы не сохранили изображение. Уверяны, что хотите продолжить?',
+    'You did not save the image. Are you sure you want to continue?' => 'Вы не сохранили изображение. Уверены, что хотите продолжить?',
 ];

--- a/views/project/screenshots.php
+++ b/views/project/screenshots.php
@@ -8,6 +8,7 @@
 
 use app\assets\ImageCropperAsset;
 use yii\helpers\Html;
+use yii\helpers\Json;
 use yii\helpers\Url;
 use yii\widgets\ActiveForm;
 
@@ -15,7 +16,7 @@ $this->title = Yii::t('project', 'Upload screenshots');
 
 ImageCropperAsset::register($this);
 $sizeThumb = Yii::$app->params['image.size.thumbnail'];
-$this->registerJs("initProjectImageUpload({$sizeThumb[0]}, {$sizeThumb[1]});");
+$this->registerJs("initProjectImageUpload({$sizeThumb[0]}, {$sizeThumb[1]}, " . Json::htmlEncode(Yii::t('project', 'You did not save the image. Are you sure you want to continue?')) . ");");
 ?>
 
 <div class="project-screenshots">


### PR DESCRIPTION
issue #60 

> On the image upload page, I keep hitting NEXT instead of UPLOAD. I think that is a UX problem.

Added alert when you want to take the next step without save image.

> On that same screen, when I choose an image, and it gets loaded onto the preview, it overlaps the text you have on the right side of the page.

I can't reproduce this error. Maybe, there is an old browser?