### PR TITLE
Remove -Disallow: /assets/

### DIFF
--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,4 +1,3 @@
 User-agent: *
-Disallow: /assets/
 
 Host: https://yiipowered.com


### PR DESCRIPTION
Google sees the page as not mobile friendly*, which may have an negative impact in the search results.

*This page can be difficult to use on a mobile device. Issues:
Text too small to read
Content wider than screen
Clickable elements too close together

It's because Googlebot can't access stylesheets and scripts in /assets/ directory. (Googlebot blocked by robots.txt)